### PR TITLE
Add initial .travis.yml config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.7"
+
+# command to install dependencies
+install: "pip install -r py.reqs.dev"
+
+# command to run tests
+script:
+  - python -m pylint aws_route_mon.py


### PR DESCRIPTION
Does a lint check on Python 2.7

Code isn't Python 3 compatible.
